### PR TITLE
JAVA 21JRE bevezetése

### DIFF
--- a/.env
+++ b/.env
@@ -19,6 +19,8 @@ POSTGRES_BASE_IMAGE_175=postgres:17.5-bullseye
 #Source images
 DOCKER_IMAGE_JAVA11JRE_NAME=icellmobilsoft/base-java11jre
 DOCKER_IMAGE_JAVA11JRE=${DOCKER_IMAGE_JAVA11JRE_NAME}:${BASE_IMAGE_VERSION}
+DOCKER_IMAGE_JAVA21JRE_NAME=dockerhub-dockerio.icellmobilsoft.hu/icellmobilsoft/base-java21jre
+DOCKER_IMAGE_JAVA21JRE=${DOCKER_IMAGE_JAVA21JRE_NAME}:${BASE_IMAGE_VERSION}
 
 
 ###############################################################################
@@ -26,6 +28,9 @@ DOCKER_IMAGE_JAVA11JRE=${DOCKER_IMAGE_JAVA11JRE_NAME}:${BASE_IMAGE_VERSION}
 ###############################################################################
 DOCKER_IMAGE_LIQUIBASE_NAME=icellmobilsoft/db-base-liquibase
 DOCKER_IMAGE_LIQUIBASE=${DOCKER_IMAGE_LIQUIBASE_NAME}:${VERSION}
+
+DOCKER_IMAGE_LIQUIBASE_NAME_431=dockerhub.icellmobilsoft.hu/db-dwh/liquibase_431
+DOCKER_IMAGE_LIQUIBASE_431=${DOCKER_IMAGE_LIQUIBASE_NAME_431}:${VERSION}
 
 DOCKER_IMAGE_POSTGRES_NAME_148=icellmobilsoft/db-base-postgres_148
 DOCKER_IMAGE_POSTGRES_148=${DOCKER_IMAGE_POSTGRES_NAME_148}:${VERSION}

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ docker compose --env-file .env -f ./docker-compose.yml build --no-cache
 To build only a specified image local testing from the repository's root directory:
 [source,bash]
 ----
-docker compose --env -file .env -f ./docker-compose.yml build --no-cache <service_name>
+docker compose --env-file .env -f ./docker-compose.yml build --no-cache <service_name>
 ----
 To start a local database from an image:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   liquibase-release:
     build:
@@ -20,6 +18,26 @@ services:
         POM_ORAI18N_EXTENSION: $ORACLE_ORAI18N_EXTENSION
         # --
     image: $DOCKER_IMAGE_LIQUIBASE
+
+  liquibase-release_431:
+    build:
+      context: .
+      dockerfile: dockerfile/liquibase/Dockerfile
+      args:
+        BASE_IMAGE: $DOCKER_IMAGE_JAVA21JRE
+        LIQUIBASE_VERSION: 4.31
+        # These are for embedding ojdbc into central Liquibase image
+        ARTIFACT_DOWNLOADER_IMAGE: $DOCKER_IMAGE_ARTIFACT_DOWNLOADER
+        POM_OJDBC_GROUP_ID: $ORACLE_OJDBC10_POM_GROUP_ID
+        POM_OJDBC_ARTIFACT_ID: $ORACLE_OJDBC10_ARTIFACT_ID
+        POM_OJDBC_VERSION: $ORACLE_OJDBC10_VERSION
+        POM_OJDBC_EXTENSION: $ORACLE_OJDBC10_EXTENSION
+        POM_ORAI18N_GROUP_ID: $ORACLE_ORAI18N_POM_GROUP_ID
+        POM_ORAI18N_ARTIFACT_ID: $ORACLE_ORAI18N_ARTIFACT_ID
+        POM_ORAI18N_VERSION: $ORACLE_ORAI18N_VERSION
+        POM_ORAI18N_EXTENSION: $ORACLE_ORAI18N_EXTENSION
+        # --
+    image: $DOCKER_IMAGE_LIQUIBASE_431    
 
   # Postgres 14.8 version
   postgres-release_148:

--- a/dockerfile/liquibase/Dockerfile
+++ b/dockerfile/liquibase/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE
 ################################################################################
 # Stage 1: Download ojdbc*.jar
 ################################################################################
-FROM $ARTIFACT_DOWNLOADER_IMAGE as download
+FROM $ARTIFACT_DOWNLOADER_IMAGE AS download
 
 ARG POM_OJDBC_GROUP_ID
 ARG POM_OJDBC_ARTIFACT_ID
@@ -38,12 +38,12 @@ RUN $HOME/script/maven-search-download.sh
 ################################################################################
 # Stage 2: Liquibase
 ################################################################################
-FROM liquibase/liquibase:$LIQUIBASE_VERSION as liqui
+FROM liquibase/liquibase:$LIQUIBASE_VERSION AS liqui
 
 ################################################################################
 # Stage 3: Base image
 ################################################################################
-FROM ${BASE_IMAGE} as base
+FROM ${BASE_IMAGE} AS base
 
 ARG LIQUIBASE_HOME_DEFAULT=$HOME/liquibase
 ENV LIQUIBASE_HOME=$LIQUIBASE_HOME_DEFAULT

--- a/docs/release-notes.adoc
+++ b/docs/release-notes.adoc
@@ -57,3 +57,4 @@ common liquibase commands.
 
 == v1.1.0
 * Postgresql 17.5 version added (icellmobilsoft/db-base-postgres_175)
+* Liquibase 4.31 version added for handling trino connections


### PR DESCRIPTION
A trino jar driver JAVA21RE -re készült.
A JAVA21JRE csak a Liquibase 4.31-es verziótól kompatibilis.
Ezért Liquibase 4.31 telepítése is szükséges.

A trino driver használata liquibase hívásban:
```
  ./liquibase \
      --log-level=INFO \
      --username=$USER \
      --password=$PASSWORD \
      --classpath="./liquibase-ext-trino-0.1.0-20250311.075338-5.jar:./trino-jdbc-472.jar" \
      --url=jdbc:trino://$DB_ADDRESS:$DB_PORT/$DATABASE/$SCHEMA \
      --changelogfile=$CHANGELOG \
      --driver-properties-file=driver.properties \
      update 2>&1
```